### PR TITLE
install git in the Dockerfile before running yarn

### DIFF
--- a/node/node-server/Dockerfile
+++ b/node/node-server/Dockerfile
@@ -1,5 +1,7 @@
 FROM amd64/node:18.13.0-alpine
 
+RUN apk add --no-cache git
+
 COPY ./ /weavedb
 
 WORKDIR /weavedb


### PR DESCRIPTION
yarn command failed inside the Dockerfile when building the node-server image